### PR TITLE
Remove dependency to vite-plugin-top-level-await.

### DIFF
--- a/ts-lib/package-lock.json
+++ b/ts-lib/package-lock.json
@@ -15,7 +15,6 @@
 				"typescript": "^5.2.2",
 				"vite": "^5.0.0",
 				"vite-plugin-dts": "^3.6.2",
-				"vite-plugin-top-level-await": "^1.3.1",
 				"vitest": "^1.4.0",
 				"webdriverio": "^8.20.4"
 			}
@@ -587,23 +586,6 @@
 				}
 			}
 		},
-		"node_modules/@rollup/plugin-virtual": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-3.0.2.tgz",
-			"integrity": "sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-			},
-			"peerDependenciesMeta": {
-				"rollup": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@rollup/pluginutils": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
@@ -918,219 +900,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/is?sponsor=1"
-			}
-		},
-		"node_modules/@swc/core": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/@swc/core/-/core-1.6.6.tgz",
-			"integrity": "sha512-sHfmIUPUXNrQTwFMVCY5V5Ena2GTOeaWjS2GFUpjLhAgVfP90OP67DWow7+cYrfFtqBdILHuWnjkTcd0+uPKlg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"@swc/counter": "^0.1.3",
-				"@swc/types": "^0.1.9"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/swc"
-			},
-			"optionalDependencies": {
-				"@swc/core-darwin-arm64": "1.6.6",
-				"@swc/core-darwin-x64": "1.6.6",
-				"@swc/core-linux-arm-gnueabihf": "1.6.6",
-				"@swc/core-linux-arm64-gnu": "1.6.6",
-				"@swc/core-linux-arm64-musl": "1.6.6",
-				"@swc/core-linux-x64-gnu": "1.6.6",
-				"@swc/core-linux-x64-musl": "1.6.6",
-				"@swc/core-win32-arm64-msvc": "1.6.6",
-				"@swc/core-win32-ia32-msvc": "1.6.6",
-				"@swc/core-win32-x64-msvc": "1.6.6"
-			},
-			"peerDependencies": {
-				"@swc/helpers": "*"
-			},
-			"peerDependenciesMeta": {
-				"@swc/helpers": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@swc/core-darwin-arm64": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.6.6.tgz",
-			"integrity": "sha512-5DA8NUGECcbcK1YLKJwNDKqdtTYDVnkfDU1WvQSXq/rU+bjYCLtn5gCe8/yzL7ISXA6rwqPU1RDejhbNt4ARLQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-darwin-x64": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.6.6.tgz",
-			"integrity": "sha512-2nbh/RHpweNRsJiYDFk1KcX7UtaKgzzTNUjwtvK5cp0wWrpbXmPvdlWOx3yzwoiSASDFx78242JHHXCIOlEdsw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-arm-gnueabihf": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.6.6.tgz",
-			"integrity": "sha512-YgytuyUfR7b0z0SRHKV+ylr83HmgnROgeT7xryEkth6JGpAEHooCspQ4RrWTU8+WKJ7aXiZlGXPgybQ4TiS+TA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-arm64-gnu": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.6.6.tgz",
-			"integrity": "sha512-yGwx9fddzEE0iURqRVwKBQ4IwRHE6hNhl15WliHpi/PcYhzmYkUIpcbRXjr0dssubXAVPVnx6+jZVDSbutvnfg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-arm64-musl": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.6.6.tgz",
-			"integrity": "sha512-a6fMbqzSAsS5KCxFJyg1mD5kwN3ZFO8qQLyJ75R/htZP/eCt05jrhmOI7h2n+1HjiG332jLnZ9S8lkVE5O8Nqw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-x64-gnu": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.6.6.tgz",
-			"integrity": "sha512-hRGsUKNzzZle28YF0dYIpN0bt9PceR9LaVBq7x8+l9TAaDLFbgksSxcnU/ubTtsy+WsYSYGn+A83w3xWC0O8CQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-x64-musl": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.6.6.tgz",
-			"integrity": "sha512-NokIUtFxJDVv3LzGeEtYMTV3j2dnGKLac59luTeq36DQLZdJQawQIdTbzzWl2jE7lxxTZme+dhsVOH9LxE3ceg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-win32-arm64-msvc": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.6.6.tgz",
-			"integrity": "sha512-lzYdI4qb4k1dFG26yv+9Jaq/bUMAhgs/2JsrLncGjLof86+uj74wKYCQnbzKAsq2hDtS5DqnHnl+//J+miZfGA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-win32-ia32-msvc": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.6.6.tgz",
-			"integrity": "sha512-bvl7FMaXIJQ76WZU0ER4+RyfKIMGb6S2MgRkBhJOOp0i7VFx4WLOnrmMzaeoPJaJSkityVKAftfNh7NBzTIydQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-win32-x64-msvc": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.6.6.tgz",
-			"integrity": "sha512-WAP0JoCTfgeYKgOeYJoJV4ZS0sQUmU3OwvXa2dYYtMLF7zsNqOiW4niU7QlThBHgUv/qNZm2p6ITEgh3w1cltw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/counter": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-			"dev": true
-		},
-		"node_modules/@swc/types": {
-			"version": "0.1.9",
-			"resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.9.tgz",
-			"integrity": "sha512-qKnCno++jzcJ4lM4NTfYifm1EFSCeIfKiAHAfkENZAV5Kl9PjJIyd2yeeVv6c/2CckuLyv2NmRC5pv6pm2WQBg==",
-			"dev": true,
-			"dependencies": {
-				"@swc/counter": "^0.1.3"
 			}
 		},
 		"node_modules/@szmarczak/http-timer": {
@@ -4960,19 +4729,6 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
 		},
-		"node_modules/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
 		"node_modules/validator": {
 			"version": "13.12.0",
 			"resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
@@ -5084,20 +4840,6 @@
 				"vite": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/vite-plugin-top-level-await": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/vite-plugin-top-level-await/-/vite-plugin-top-level-await-1.4.1.tgz",
-			"integrity": "sha512-hogbZ6yT7+AqBaV6lK9JRNvJDn4/IJvHLu6ET06arNfo0t2IsyCaon7el9Xa8OumH+ESuq//SDf8xscZFE0rWw==",
-			"dev": true,
-			"dependencies": {
-				"@rollup/plugin-virtual": "^3.0.2",
-				"@swc/core": "^1.3.100",
-				"uuid": "^9.0.1"
-			},
-			"peerDependencies": {
-				"vite": ">=2.8"
 			}
 		},
 		"node_modules/vitest": {

--- a/ts-lib/package.json
+++ b/ts-lib/package.json
@@ -54,7 +54,6 @@
 		"typescript": "^5.2.2",
 		"vite": "^5.0.0",
 		"vite-plugin-dts": "^3.6.2",
-		"vite-plugin-top-level-await": "^1.3.1",
 		"vitest": "^1.4.0",
 		"webdriverio": "^8.20.4"
 	}

--- a/ts-lib/src/smol-string-worker.ts
+++ b/ts-lib/src/smol-string-worker.ts
@@ -1,6 +1,6 @@
-import Worker from "./worker.js?worker";
-
-const worker = new Worker();
+const worker = new Worker(new URL("./worker.ts", import.meta.url), {
+	type: "module",
+});
 
 let nextID = 0;
 const resolver: Record<number, (str: string) => void> = {};

--- a/ts-lib/vite.config.ts
+++ b/ts-lib/vite.config.ts
@@ -3,8 +3,6 @@ import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import pkg from "./package.json" assert { type: "json" };
 
-import topLevelAwait from "vite-plugin-top-level-await";
-
 export default defineConfig({
 	base: "./",
 	build: {
@@ -25,16 +23,6 @@ export default defineConfig({
 	},
 	worker: {
 		format: "es",
-		plugins() {
-			return [
-				topLevelAwait({
-					// The export name of top-level await promise for each chunk module
-					promiseExportName: "__tla",
-					// The function to generate import names of top-level await promise in each chunk module
-					promiseImportName: (i) => `__tla_${i}`,
-				}),
-			];
-		},
 	},
 	plugins: [
 		dts(), // emit TS declaration files


### PR DESCRIPTION
We were targeting esnext already, the only thing missing was specifying type:module for the worker instanciation.